### PR TITLE
Add initial Idea Parser prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# ideaparser
+# Idea Parser
+
+Simple prototype for collecting trend signals and generating idea cards.
+
+## Services
+- **backend** – FastAPI app with scheduled collectors and LangChain agent.
+- **frontend** – minimal React UI served by Nginx.
+- **postgres** – database for storing raw trends and ideas.
+- **redis** – cache / background jobs.
+
+## Development
+```
+docker-compose up --build
+```
+Backend available at `http://localhost:8000`, frontend at `http://localhost:3000`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/aggregator.py
+++ b/backend/app/aggregator.py
@@ -1,0 +1,17 @@
+from datetime import date
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from .models import TrendRaw, DailyHotTopic
+
+
+def compute_daily_scores(db: Session):
+    today = date.today()
+    results = (
+        db.query(TrendRaw.keyword, func.sum(TrendRaw.value).label('score'))
+        .filter(TrendRaw.date == today)
+        .group_by(TrendRaw.keyword)
+        .all()
+    )
+    for keyword, score in results:
+        db.add(DailyHotTopic(keyword=keyword, trend_score=score, date=today))
+    db.commit()

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+import os
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/postgres")
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/idea_agent.py
+++ b/backend/app/idea_agent.py
@@ -1,0 +1,62 @@
+from langchain.agents import initialize_agent, Tool
+from langchain.llms import OpenAI
+from langchain.tools import DuckDuckGoSearchRun
+from langchain import LLMChain
+from langchain.prompts import PromptTemplate
+from sqlalchemy.orm import Session
+from .models import IdeaCard, DailyHotTopic
+
+
+def generate_idea_cards(db: Session):
+    top_topics = db.query(DailyHotTopic).order_by(DailyHotTopic.trend_score.desc()).limit(10).all()
+    if not top_topics:
+        return
+    llm = OpenAI(temperature=0)
+    search = DuckDuckGoSearchRun()
+    tools = [Tool(name='web_search', func=search.run, description='search the web')]
+    agent = initialize_agent(tools, llm, agent="zero-shot-react-description")
+
+    template = (
+        "Generate idea card for '{topic}' in format:\n"
+        "Problem: ...\nSolution: ...\nTAM: ...\nWhy Now: ...\nNext Steps: ..."
+    )
+    prompt = PromptTemplate(input_variables=['topic'], template=template)
+    chain = LLMChain(llm=llm, prompt=prompt)
+
+    for t in top_topics:
+        result = chain.run(topic=t.keyword)
+        parts = {p.split(':')[0].strip().lower(): p.split(':')[1].strip() for p in result.split('\n') if ':' in p}
+        card = IdeaCard(
+            keyword=t.keyword,
+            problem=parts.get('problem', ''),
+            solution=parts.get('solution', ''),
+            tam=parts.get('tam', ''),
+            why_now=parts.get('why now', ''),
+            next_steps=parts.get('next steps', ''),
+        )
+        db.add(card)
+    db.commit()
+
+
+def generate_hypothesis_card(db: Session, description: str) -> IdeaCard:
+    llm = OpenAI(temperature=0)
+    template = (
+        "For the following idea description generate TAM, Competitors and Risks:\n"
+        "{desc}\nTAM: \nCompetitors: \nRisks:"
+    )
+    prompt = PromptTemplate(input_variables=['desc'], template=template)
+    chain = LLMChain(llm=llm, prompt=prompt)
+    result = chain.run(desc=description)
+    parts = {p.split(':')[0].strip().lower(): p.split(':')[1].strip() for p in result.split('\n') if ':' in p}
+    card = IdeaCard(
+        keyword=description[:50],
+        problem='',
+        solution='',
+        tam=parts.get('tam', ''),
+        why_now='',
+        next_steps='',
+        hypothesis=description + '\n' + result
+    )
+    db.add(card)
+    db.commit()
+    return card

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI, Depends, WebSocket, BackgroundTasks
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+from .db import Base, engine, get_db
+from .models import DailyHotTopic, IdeaCard
+from .idea_agent import generate_idea_cards, generate_hypothesis_card
+from .aggregator import compute_daily_scores
+from .trending import collect_trend
+from . import tasks  # start background scheduler
+import asyncio
+
+app = FastAPI()
+
+Base.metadata.create_all(bind=engine)
+
+@app.get("/topics")
+def read_topics(db: Session = Depends(get_db)):
+    topics = db.query(DailyHotTopic).order_by(DailyHotTopic.trend_score.desc()).limit(10).all()
+    return topics
+
+@app.post("/ideas")
+async def create_ideas(db: Session = Depends(get_db)):
+    await asyncio.get_event_loop().run_in_executor(None, generate_idea_cards, db)
+    return {"status": "processing"}
+
+
+@app.post("/hypotheses")
+async def create_hypothesis(description: str, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
+    def run():
+        generate_hypothesis_card(db, description)
+    background_tasks.add_task(run)
+    return {"status": "processing"}
+
+@app.get("/hypotheses/{card_id}")
+def read_hypothesis(card_id: int, db: Session = Depends(get_db)):
+    card = db.query(IdeaCard).filter(IdeaCard.id == card_id).first()
+    if card:
+        return card
+    return JSONResponse(status_code=404, content={"detail": "Not found"})
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    await ws.send_text("ready")
+    await ws.close()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, Integer, String, Date, Float, Text
+from .db import Base
+
+class TrendRaw(Base):
+    __tablename__ = "trend_raw"
+    id = Column(Integer, primary_key=True, index=True)
+    source = Column(String, index=True)
+    keyword = Column(String, index=True)
+    date = Column(Date, index=True)
+    value = Column(Float)
+
+class DailyHotTopic(Base):
+    __tablename__ = "daily_hot_topics"
+    id = Column(Integer, primary_key=True, index=True)
+    keyword = Column(String, index=True)
+    trend_score = Column(Float)
+    date = Column(Date, index=True)
+
+class IdeaCard(Base):
+    __tablename__ = "idea_cards"
+    id = Column(Integer, primary_key=True, index=True)
+    keyword = Column(String, index=True)
+    problem = Column(Text)
+    solution = Column(Text)
+    tam = Column(Text)
+    why_now = Column(Text)
+    next_steps = Column(Text)
+    hypothesis = Column(Text, nullable=True)

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,24 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from .db import SessionLocal
+from .trending import collect_trend
+from .aggregator import compute_daily_scores
+
+KEYWORDS = ["AI", "Blockchain", "Startup"]
+
+scheduler = BackgroundScheduler()
+
+def collect_job():
+    db = SessionLocal()
+    for kw in KEYWORDS:
+        collect_trend(db, kw)
+    db.close()
+
+def aggregate_job():
+    db = SessionLocal()
+    compute_daily_scores(db)
+    db.close()
+
+scheduler.add_job(collect_job, 'interval', hours=6)
+scheduler.add_job(aggregate_job, 'cron', hour=0)
+
+scheduler.start()

--- a/backend/app/trending.py
+++ b/backend/app/trending.py
@@ -1,0 +1,30 @@
+from datetime import date
+from pytrends.request import TrendReq
+import praw
+from sqlalchemy.orm import Session
+from .models import TrendRaw
+
+# Placeholder functions for Twitter/X and Product Hunt
+
+def fetch_google_trends(keyword: str) -> float:
+    pytrend = TrendReq()
+    pytrend.build_payload([keyword])
+    data = pytrend.interest_over_time()
+    if not data.empty:
+        return float(data[keyword].iloc[-1])
+    return 0.0
+
+def fetch_reddit_mentions(keyword: str) -> float:
+    reddit = praw.Reddit(client_id='dummy', client_secret='dummy', user_agent='trend_collector')
+    count = sum(1 for _ in reddit.subreddit('all').search(keyword, limit=100))
+    return float(count)
+
+# TODO: implement twitter_x_mentions and product_hunt_mentions
+
+def collect_trend(db: Session, keyword: str):
+    gt = fetch_google_trends(keyword)
+    rd = fetch_reddit_mentions(keyword)
+    today = date.today()
+    db.add(TrendRaw(source='google_trends', keyword=keyword, date=today, value=gt))
+    db.add(TrendRaw(source='reddit', keyword=keyword, date=today, value=rd))
+    db.commit()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,12 @@
+fastapi
+uvicorn
+SQLAlchemy
+psycopg2-binary
+pydantic
+pytrends
+praw
+langchain
+openai
+redis
+websockets
+apscheduler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:13
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  redis:
+    image: redis:alpine
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+volumes:
+  pgdata:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html
+EXPOSE 80

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Idea Parser</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+function App() {
+  const [topics, setTopics] = React.useState([]);
+  const [msg, setMsg] = React.useState('');
+
+  React.useEffect(() => {
+    fetch('/topics').then(r => r.json()).then(setTopics);
+  }, []);
+
+  const generateIdeas = () => {
+    fetch('/ideas', {method: 'POST'}).then(() => setMsg('Processing ideas...'));
+  };
+
+  return (
+    <div>
+      <h1>Hot Topics</h1>
+      <ul>{topics.map(t => <li key={t.id}>{t.keyword} ({t.trend_score})</li>)}</ul>
+      <button onClick={generateIdeas}>Generate Ideas</button>
+      <p>{msg}</p>
+    </div>
+  );
+}
+ReactDOM.render(<App />, document.getElementById('root'));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up FastAPI backend with scheduled trend collection
- add LangChain agent for generating idea cards and hypotheses
- include simple React frontend served by Nginx
- provide Docker setup with postgres and redis

## Testing
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_68533d52dcc0832bb7c8f883b9066797